### PR TITLE
feat: add basic user model and API

### DIFF
--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API routers."""
+
+from . import users
+
+__all__ = ["users"]

--- a/server/app/api/users.py
+++ b/server/app/api/users.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from ..db import get_session
+from ..models import User, UserCreate, UserRead
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def hash_password(password: str) -> str:
+    return sha256(password.encode()).hexdigest()
+
+
+@router.post("/", response_model=UserRead)
+def create_user(user: UserCreate, session: Session = Depends(get_session)) -> User:
+    existing = session.exec(select(User).where(User.email == user.email)).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    db_user = User(email=user.email, password_hash=hash_password(user.password))
+    session.add(db_user)
+    session.commit()
+    session.refresh(db_user)
+    return db_user
+
+
+@router.get("/{user_id}", response_model=UserRead)
+def read_user(user_id: int, session: Session = Depends(get_session)) -> User:
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user

--- a/server/app/db.py
+++ b/server/app/db.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./pyssistown.db"
+
+engine = create_engine(
+    DATABASE_URL, echo=False, connect_args={"check_same_thread": False}
+)
+
+
+def init_db() -> None:
+    """Create database tables."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    """Provide a transactional scope around a series of operations."""
+    with Session(engine) as session:
+        yield session

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,11 +1,29 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .ws import router as ws_router
+from .api import users
+from .db import init_db
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
 
 @app.get("/")
 async def read_root() -> dict[str, str]:
     return {"status": "ok"}
 
+
+app.include_router(users.router)
 app.include_router(ws_router)

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -1,0 +1,5 @@
+"""ORM models."""
+
+from .user import User, UserCreate, UserRead
+
+__all__ = ["User", "UserCreate", "UserRead"]

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+
+
+class UserBase(SQLModel):
+    email: str = Field(index=True, unique=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class User(UserBase, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    password_hash: str
+
+
+class UserRead(UserBase):
+    id: int
+
+
+class UserCreate(SQLModel):
+    email: str
+    password: str

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+from sqlalchemy.pool import StaticPool
+
+from server.app.main import app
+from server.app.db import get_session
+
+
+def get_test_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def get_session_override():
+        with Session(engine) as session:
+            yield session
+
+    return get_session_override
+
+
+def test_create_and_read_user() -> None:
+    override = get_test_session()
+    app.dependency_overrides[get_session] = override
+    client = TestClient(app)
+
+    response = client.post("/users/", json={"email": "a@b.com", "password": "secret"})
+    assert response.status_code == 200
+    user = response.json()
+    assert user["id"] == 1
+    assert user["email"] == "a@b.com"
+
+    response = client.get(f"/users/{user['id']}")
+    assert response.status_code == 200
+    user_get = response.json()
+    assert user_get["email"] == "a@b.com"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- set up SQLModel engine and session helpers
- add User ORM model and CRUD endpoints
- expose user routes with CORS-enabled FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896428b160c8327aae19c3aceaf9acb