### PR TITLE
Implement JWT authentication scaffold

### DIFF
--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 
-from . import users
+from . import users, auth
 
-__all__ = ["users"]
+__all__ = ["users", "auth"]

--- a/server/app/api/auth.py
+++ b/server/app/api/auth.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session, select
+
+from ..db import get_session
+from ..models import User, UserRead
+from ..security.auth import (
+    create_access_token,
+    verify_password,
+    get_current_user,
+)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/token")
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    session: Session = Depends(get_session),
+) -> dict[str, str]:
+    user = session.exec(select(User).where(User.email == form_data.username)).first()
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Incorrect email or password")
+    token = create_access_token({"sub": str(user.id)})
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.get("/me", response_model=UserRead)
+def read_me(current_user: User = Depends(get_current_user)) -> User:
+    return current_user

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .ws import router as ws_router
-from .api import users
+from .api import users, auth
 from .db import init_db
 
 app = FastAPI()
@@ -26,4 +26,5 @@ async def read_root() -> dict[str, str]:
 
 
 app.include_router(users.router)
+app.include_router(auth.router)
 app.include_router(ws_router)

--- a/server/app/security/__init__.py
+++ b/server/app/security/__init__.py
@@ -1,0 +1,15 @@
+"""Security utilities."""
+
+from .auth import (
+    create_access_token,
+    get_current_user,
+    get_password_hash,
+    verify_password,
+)
+
+__all__ = [
+    "create_access_token",
+    "get_current_user",
+    "get_password_hash",
+    "verify_password",
+]

--- a/server/app/security/auth.py
+++ b/server/app/security/auth.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from hashlib import sha256
+from typing import Any, Dict
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlmodel import Session
+
+from ..db import get_session
+from ..models import User
+
+SECRET_KEY = os.getenv("JWT_SECRET", "dev-secret")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+def get_password_hash(password: str) -> str:
+    return sha256(password.encode()).hexdigest()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return get_password_hash(plain_password) == hashed_password
+
+
+def create_access_token(data: Dict[str, Any], expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = int(payload.get("sub"))
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
     "uvicorn[standard]",
     "sqlmodel",
     "alembic",
+    "pyjwt",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from server.app.main import app
+from server.app.db import get_session
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def get_session_override() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_session_override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+def test_login_and_me(client) -> None:
+    client.post("/users/", json={"email": "a@b.com", "password": "secret"})
+
+    response = client.post(
+        "/auth/token",
+        data={"username": "a@b.com", "password": "secret"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    user = response.json()
+    assert user["email"] == "a@b.com"

--- a/server/tests/test_main.py
+++ b/server/tests/test_main.py
@@ -1,14 +1,7 @@
-from pathlib import Path
-import sys
+from __future__ import annotations
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from server.app.main import app
-from fastapi.testclient import TestClient
-
-client = TestClient(app)
-
-def test_root() -> None:
+def test_root(client) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -1,36 +1,7 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
-
-from fastapi.testclient import TestClient
-from sqlmodel import SQLModel, create_engine, Session
-from sqlalchemy.pool import StaticPool
-
-from server.app.main import app
-from server.app.db import get_session
+from __future__ import annotations
 
 
-def get_test_session():
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SQLModel.metadata.create_all(engine)
-
-    def get_session_override():
-        with Session(engine) as session:
-            yield session
-
-    return get_session_override
-
-
-def test_create_and_read_user() -> None:
-    override = get_test_session()
-    app.dependency_overrides[get_session] = override
-    client = TestClient(app)
-
+def test_create_and_read_user(client) -> None:
     response = client.post("/users/", json={"email": "a@b.com", "password": "secret"})
     assert response.status_code == 200
     user = response.json()
@@ -41,5 +12,3 @@ def test_create_and_read_user() -> None:
     assert response.status_code == 200
     user_get = response.json()
     assert user_get["email"] == "a@b.com"
-
-    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add JWT generation/verification utilities
- expose `/auth/token` and `/auth/me` endpoints
- centralize password hashing and add auth tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896440176108327af333ddc3eeac073