### PR TITLE
feat: add JWT-authenticated game websocket

### DIFF
--- a/server/app/ws.py
+++ b/server/app/ws.py
@@ -1,10 +1,25 @@
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from sqlmodel import Session
+
+from .db import get_session
+from .security.auth import get_user_from_token
 
 router = APIRouter()
 
-@router.websocket("/ws")
-async def websocket_endpoint(ws: WebSocket) -> None:
-    """Simple echo WebSocket endpoint."""
+
+@router.websocket("/ws/game")
+async def websocket_endpoint(
+    ws: WebSocket,
+    room: str,
+    token: str,
+    session: Session = Depends(get_session),
+) -> None:
+    """Echo WebSocket endpoint that requires JWT auth and a room."""
+    try:
+        get_user_from_token(token, session)
+    except ValueError:
+        await ws.close(code=1008)
+        return
     await ws.accept()
     try:
         while True:

--- a/server/tests/test_ws.py
+++ b/server/tests/test_ws.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+
+def test_ws_requires_token(client) -> None:
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws/game?room=main"):
+            pass
+    assert exc.value.code == 1008
+
+
+def test_ws_echo(client) -> None:
+    client.post("/users/", json={"email": "a@b.com", "password": "secret"})
+    token_resp = client.post(
+        "/auth/token",
+        data={"username": "a@b.com", "password": "secret"},
+    )
+    token = token_resp.json()["access_token"]
+
+    with client.websocket_connect(f"/ws/game?room=main&token={token}") as ws:
+        ws.send_text("ping")
+        data = ws.receive_text()
+        assert data == "ping"


### PR DESCRIPTION
## Summary
- refactor auth utilities to expose token decoding helper
- add `/ws/game` endpoint requiring JWT token and room
- cover WebSocket auth and echo behavior with tests

## Testing
- `cd server && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964583a4e883279401cbe41bc14672